### PR TITLE
Adds the HEAD method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,7 @@ To preview how HTTP Prompt is going to call HTTPie_, do::
 To actually send a request, enter one of the HTTP methods::
 
     > get
+    > head
     > post
     > put
     > patch

--- a/http_prompt/completer.py
+++ b/http_prompt/completer.py
@@ -23,6 +23,7 @@ ROOT_COMMANDS = [
 ACTIONS = [
     ('delete', 'DELETE request'),
     ('get', 'GET request'),
+    ('head', 'HEAD request'),
     ('patch', 'GET request'),
     ('post', 'POST request'),
     ('put', 'PUT request'),
@@ -71,7 +72,7 @@ RULES = [
     (r'((?:[^\s\'"\\=:]|(?:\\.))+):((?:[^\s\'"\\]|(?:\\.))*)$',
      'header_values'),
 
-    (r'(get|post|put|patch|delete)\s+', 'concat_mutations'),
+    (r'(get|head|post|put|patch|delete)\s+', 'concat_mutations'),
     (r'(httpie|curl)\s+', 'preview'),
     (r'rm\s+\-b\s+', 'existing_body_params'),
     (r'rm\s+\-h\s+', 'existing_header_names'),

--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -64,7 +64,8 @@ grammar = Grammar(r"""
     cd = _ "cd" _ string _
     rm = _ "rm" _ ~r"\-(h|q|b|o)" _ mutkey _
     tool = "httpie" / "curl"
-    method = ~r"get"i / ~r"post"i / ~r"put"i / ~r"delete"i / ~r"patch"i
+    method = ~r"get"i / ~r"head"i / ~r"post"i / ~r"put"i / ~r"delete"i /
+             ~r"patch"i
     mutkey = unquoted_mutkey / ("'" squoted_mutkey "'") /
              ('"' dquoted_mutkey '"') / flag_optname / value_optname
 

--- a/http_prompt/lexer.py
+++ b/http_prompt/lexer.py
@@ -40,7 +40,7 @@ class HttpPromptLexer(RegexLexer):
             (r'(cd)(\s*)', bygroups(Keyword, Text), 'cd'),
             (r'(rm)(\s*)', bygroups(Keyword, Text), 'rm_option'),
             (r'(httpie|curl)(\s*)', bygroups(Keyword, Text), 'preview_action'),
-            (r'(?i)(get|post|put|patch|delete)(\s*)',
+            (r'(?i)(get|head|post|put|patch|delete)(\s*)',
              bygroups(Keyword, Text), 'urlpath'),
             (r'exit\s*', Keyword, 'end'),
             (r'', Text, 'concat_mut')
@@ -93,7 +93,7 @@ class HttpPromptLexer(RegexLexer):
         ],
 
         'preview_action': [
-            (r'(?i)(get|post|put|patch|delete)(\s*)',
+            (r'(?i)(get|head|post|put|patch|delete)(\s*)',
              bygroups(Keyword, Text), 'urlpath'),
             (r'', Text, 'urlpath')
         ],

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -312,6 +312,14 @@ class TestHttpAction(ExecutionTestCase):
         execute('PATCH', self.context)
         self.assert_httpie_main_called_with(['PATCH', 'http://localhost'])
 
+    def test_head(self):
+        execute('head', self.context)
+        self.assert_httpie_main_called_with(['HEAD', 'http://localhost'])
+
+    def test_head_uppercase(self):
+        execute('HEAD', self.context)
+        self.assert_httpie_main_called_with(['HEAD', 'http://localhost'])
+
 
 class TestCommandPreview(ExecutionTestCase):
 


### PR DESCRIPTION


Test added and passed.

```
→ python -m pytest
========================================================================== test session starts ==========================================================================
platform darwin -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /Users/karl/code/http-prompt, inifile: tox.ini
plugins: cov-2.2.1
collected 77 items 

tests/test_context.py .......
tests/test_execution.py ..................................................
tests/test_lexer.py ....................
----------------------------------------------------------- coverage: platform darwin, python 2.7.10-final-0 ------------------------------------------------------------
Name                       Stmts   Miss  Cover   Missing
--------------------------------------------------------
http_prompt/__init__.py        1      0   100%   
http_prompt/cli.py            39     39     0%   1-57
http_prompt/completer.py      98     98     0%   1-217
http_prompt/context.py        43      2    95%   40, 56
http_prompt/execution.py     161     12    93%   236-237, 255, 269-272, 277-288
http_prompt/lexer.py          13      0   100%   
http_prompt/options.py         7      0   100%   
http_prompt/utils.py           8      0   100%   
--------------------------------------------------------
TOTAL                        370    151    59%   

======================================================================= 77 passed in 0.49 seconds =======================================================================
```