### PR TITLE
Fix #5: Remove quotes from HTTPie arguments

### DIFF
--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -231,10 +231,11 @@ class ExecutionVisitor(NodeVisitor):
 
         if children[0].expr_name == 'preview':
             if self.tool == 'httpie':
-                command = ['http'] + context.httpie_args(self.method)
+                command = ['http'] + context.httpie_args(self.method,
+                                                         quote=True)
             else:
                 assert self.tool == 'curl'
-                command = ['curl'] + context.curl_args(self.method)
+                command = ['curl'] + context.curl_args(self.method, quote=True)
             click.echo(' '.join(command))
         else:
             assert children[0].expr_name == 'action'

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -65,7 +65,7 @@ def test_httpie_args_get():
     assert args == [
         'GET', 'http://localhost/things',
         'limit==10', 'page==2',
-        'Accept:text/html', "Authorization:'ApiKey 1234'",
+        'Accept:text/html', "Authorization:ApiKey 1234",
     ]
 
 
@@ -84,6 +84,14 @@ def test_httpie_args_post():
     args = c.httpie_args('post')
     assert args == [
         '--form', 'POST', 'http://localhost/things',
-        'email=jane@example.com', "name='Jane Doe'",
-        'Accept:text/html', "Authorization:'ApiKey 1234'",
+        'email=jane@example.com', "name=Jane Doe",
+        'Accept:text/html', "Authorization:ApiKey 1234",
+    ]
+
+    # Test quote option
+    args = c.httpie_args('post', quote=True)
+    assert args == [
+        '--form', 'POST', 'http://localhost/things',
+        'email=jane@example.com', "'name=Jane Doe'",
+        'Accept:text/html', "'Authorization:ApiKey 1234'",
     ]

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -353,3 +353,15 @@ class TestCommandPreview(ExecutionTestCase):
             'http POST https://httpbin.org/post name=alice')
         self.assertEqual(self.context.url, 'http://localhost')
         self.assertFalse(self.context.body_params)
+
+    def test_httpie_with_quotes(self):
+        execute(r'httpie post http://httpbin.org/post name="john doe" '
+                r"apikey==abc\ 123 'Authorization:ApiKey 1234'",
+                self.context)
+        self.click.echo.assert_called_with(
+            "http POST http://httpbin.org/post 'apikey==abc 123' "
+            "'name=john doe' 'Authorization:ApiKey 1234'")
+        self.assertEqual(self.context.url, 'http://localhost')
+        self.assertFalse(self.context.body_params)
+        self.assertFalse(self.context.querystring_params)
+        self.assertFalse(self.context.headers)


### PR DESCRIPTION
When passing arguments to `httpie.core.main`, no need to add quotes. But when previewing httpie command (using `httpie get ...` command), we need to quote the arguments.