### PR TITLE
Fix #3: Don't strip trailing slash from URL

### DIFF
--- a/http_prompt/context.py
+++ b/http_prompt/context.py
@@ -6,8 +6,6 @@ from .utils import smart_quote
 class Context(object):
 
     def __init__(self, url=None):
-        if url.endswith('/'):
-            url = url[:-1]
         self.url = url
         self.headers = {}
         self.querystring_params = {}

--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -87,8 +87,8 @@ grammar = Grammar(r"""
 def urljoin2(base, path, **kwargs):
     if not base.endswith('/'):
         base += '/'
-    url = urljoin(base, path)
-    if url.endswith('/'):
+    url = urljoin(base, path, **kwargs)
+    if url.endswith('/') and not path.endswith('/'):
         url = url[:-1]
     return url
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -6,11 +6,6 @@ def test_creation():
     assert context.url == 'http://example.com'
 
 
-def test_creation_with_trailing_slash_url():
-    context = Context('http://example.com/')
-    assert context.url == 'http://example.com'
-
-
 def test_creation_with_longer_url():
     context = Context('http://example.com/a/b/c/index.html')
     assert context.url == 'http://example.com/a/b/c/index.html'

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -54,15 +54,28 @@ class TestExecution_cd(ExecutionTestCase):
         execute('cd ..', self.context)
         self.assertEqual(self.context.url, 'http://localhost/api')
 
-        execute('cd ../rest/api', self.context)
-        self.assertEqual(self.context.url, 'http://localhost/rest/api')
+        # If dot-dot has a trailing slash, the resulting URL should have a
+        # trailing slash
+        execute('cd ../rest/api/', self.context)
+        self.assertEqual(self.context.url, 'http://localhost/rest/api/')
 
-    def test_trailing_slash(self):
-        execute('cd api/', self.context)
+    def test_url_with_trailing_slash(self):
+        self.context.url = 'http://localhost/'
+        execute('cd api', self.context)
         self.assertEqual(self.context.url, 'http://localhost/api')
 
+        execute('cd v2/', self.context)
+        self.assertEqual(self.context.url, 'http://localhost/api/v2/')
+
+        execute('cd /objects/', self.context)
+        self.assertEqual(self.context.url, 'http://localhost/objects/')
+
+    def test_path_with_trailing_slash(self):
+        execute('cd api/', self.context)
+        self.assertEqual(self.context.url, 'http://localhost/api/')
+
         execute('cd movie/1/', self.context)
-        self.assertEqual(self.context.url, 'http://localhost/api/movie/1')
+        self.assertEqual(self.context.url, 'http://localhost/api/movie/1/')
 
 
 class TestExecution_rm(ExecutionTestCase):


### PR DESCRIPTION
This PR respects user's trailing slash:

```
$ http-prompt http://localhost/
http://localhost/> cd api/v1
http://localhost/api/v1> cd things/
http://localhost/api/v1/things/> cd ..
http://localhost/api/v1> cd ../
http://localhost/api/>
```