### PR TITLE
Add Dockerfile for building docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.*
+*.gif
+dist/
+build/
+*.egg*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:alpine
+
+ADD . /http-prompt/
+
+RUN cd http-prompt && python setup.py install && cd ..
+
+ENTRYPOINT ["http-prompt"]


### PR DESCRIPTION
Not sure if this is something appropriate in the repo, but I'm a fan of leveraging docker for running tools.

To build:
```
docker build -t http-prompt .
```
and to run:
```
docker run -it --rm http-prompt
```

If this is appropriate, next steps would be setting up an automated build on docker/hub that would build on every merge etc. I've done that already for my fork here https://hub.docker.com/r/frosforever/http-prompt/. The image can be pulled down and run via:
```
docker run -it --rm frosforever/http-prompt
```

See https://docs.docker.com/docker-hub/builds/ for the steps required to set up an automated build.