### PR TITLE
Added help command and NOP command

### DIFF
--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -10,6 +10,7 @@ from pygments.styles import get_style_by_name
 
 from . import __version__
 from .completer import HttpPromptCompleter
+from .completer import echo_help
 from .context import Context
 from .execution import execute
 from .lexer import HttpPromptLexer
@@ -52,8 +53,10 @@ def cli(url):
         else:
             if text == 'exit':
                 break
-            if text == '':
+            elif text == '':
                 continue
+            elif text == 'help':
+                echo_help()
             else:
                 execute(text, context)
 

--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -46,11 +46,14 @@ def cli(url):
         try:
             text = prompt('%s> ' % context.url, completer=completer,
                           lexer=lexer, style=style, history=history)
+            text = text.strip()
         except EOFError:
             break  # Control-D pressed
         else:
-            if text.strip() == 'exit':
+            if text == 'exit':
                 break
+            if text == '':
+                continue
             else:
                 execute(text, context)
 

--- a/http_prompt/completer.py
+++ b/http_prompt/completer.py
@@ -1,6 +1,8 @@
 import re
 import six
 
+import click
+
 from collections import OrderedDict
 from itertools import chain
 
@@ -18,6 +20,7 @@ ROOT_COMMANDS = [
     ('curl', 'Preview curl command'),
     ('httpie', 'Preview HTTPie command'),
     ('exit', 'Exit HTTP Prompt'),
+    ('help', 'List commands, option flags, and actions'),
 ]
 
 ACTIONS = [
@@ -90,6 +93,29 @@ def compile_rules(rules):
     return compiled_rules
 
 RULES = compile_rules(RULES)
+
+
+def echo_help():
+    """Prints a formatted list of current commands, option flags, http actions
+    (and their support values)
+    """
+    def echo_cmds_with_explanations(summary, cmds):
+        click.echo('\n{}:'.format(summary))
+        for cmd, explanation in cmds:
+            click.echo('\t{:<10}\t{:<20}'.format(cmd, explanation))
+
+    click.echo('\nInteractive usage: http-prompt')
+    echo_cmds_with_explanations('Commands', ROOT_COMMANDS.items())
+    echo_cmds_with_explanations('Options', OPTION_NAMES.items())
+    echo_cmds_with_explanations('Actions', ACTIONS.items())
+    echo_cmds_with_explanations(
+        'Headers',
+        [
+            (key, ', '.join(HEADER_VALUES[key])) if key in HEADER_VALUES else (key, '')
+            for key in HEADER_NAMES.keys()
+        ]
+    )
+    click.echo()
 
 
 def fuzzyfinder(text, collection):

--- a/http_prompt/options.py
+++ b/http_prompt/options.py
@@ -9,7 +9,7 @@ FLAG_OPTIONS = [
     ('--follow', 'Allow full redirects'),
     ('--form', 'Send as form fields'),
     ('--headers', 'Print only response headers'),
-    ('--help', 'Show help message'),
+    ('--help', 'Show tool (HTTPie, cURL) help message'),
     ('--ignore-stdin', 'Do not read stdin'),
     ('--json', 'Send as a JSON object (default)'),
     ('--stream', 'Stream the output'),


### PR DESCRIPTION
fix #15. 

1. Hitting enter with a only whitespace entered is treated as a NOP command. No syntax error is printed.
2. Added a 'help' command that lists current commands, option flags, actions and headers.