### PR TITLE
Handle extra arguments as initial http options.

### DIFF
--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -25,9 +25,12 @@ def fix_incomplete_url(url):
     return url
 
 
-@click.command()
+@click.command(context_settings=dict(
+    ignore_unknown_options=True,
+))
 @click.argument('url', default='http://localhost')
-def cli(url):
+@click.argument('http_options', nargs=-1, type=click.UNPROCESSED)
+def cli(url, http_options):
     click.echo('Version: %s' % __version__)
 
     # Override less options
@@ -41,6 +44,10 @@ def cli(url):
     lexer = PygmentsLexer(HttpPromptLexer)
     completer = HttpPromptCompleter(context)
     style = style_from_pygments(get_style_by_name('monokai'))
+
+    # Execute default http options.
+    if http_options:
+        execute(' '.join(http_options), context)
 
     while True:
         try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,26 @@
+from mock import patch, ANY
+
+from http_prompt.cli import cli, execute
+from click.testing import CliRunner
+
+
+@patch('http_prompt.cli.prompt')
+@patch('http_prompt.cli.execute')
+def test_cli_unknown_options(execute_mock, prompt_mock):
+    # Emulate a Ctrl+D on first call.
+    prompt_mock.side_effect = EOFError
+    execute_mock.side_effect = execute
+
+    url = 'http://example.com'
+    custom_args = '--auth value: name=foo'
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [url] + custom_args.split())
+
+    assert result.exit_code == 0
+    execute_mock.assert_called_with(custom_args, ANY)
+
+    context = execute_mock.call_args[0][1]
+    assert context.url == url
+    assert context.options == {'--auth': 'value:'}
+    assert context.body_params == {'name': 'foo'}


### PR DESCRIPTION
The motivation of this feature is to be able to pass environment
variables. Although, the drawback is that requires the URL argument to
be passed first, otherwise the first argument will be taken as URL.

Example:

    $ export MYAUTH=a1b2c3d4
    $ http-prompt http://httpbin.org/get --auth $MYAUTH:
    Version: 0.2.1dev
    http://httpbin.org/get> httpie
    http --auth auth: http://httpbin.org/get