### PR TITLE
Persistent context

### DIFF
--- a/http_prompt/context.py
+++ b/http_prompt/context.py
@@ -1,5 +1,8 @@
 import six
 
+from copy import deepcopy
+
+from . import __version__
 from .utils import smart_quote
 
 
@@ -77,3 +80,11 @@ class Context(object):
 
     def curl_args(self, quote=False):
         raise NotImplementedError('curl is not supported yet')
+
+    def json_obj(self):
+        obj = deepcopy(self.__dict__)
+        obj['__version__'] = __version__
+        return obj
+
+    def load_from_json_obj(self, json_obj):
+        self.__dict__ = deepcopy(json_obj)

--- a/http_prompt/xdg.py
+++ b/http_prompt/xdg.py
@@ -1,0 +1,37 @@
+"""XDG Base Directory Specification.
+
+See:
+    https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+    https://github.com/ActiveState/appdirs
+"""
+import os
+import sys
+
+from functools import partial
+
+
+def _get_dir(envvar_name, default_dir, resource_name=None):
+    base_dir = os.getenv(envvar_name) or default_dir
+    app_dir = os.path.join(base_dir, 'http-prompt')
+    if not os.path.exists(app_dir):
+        os.makedirs(app_dir, mode=0o700)
+
+    if resource_name:
+        app_dir = os.path.join(app_dir, resource_name)
+        if not os.path.exists(app_dir):
+            os.mkdir(app_dir)
+
+    return app_dir
+
+
+if sys.platform == 'win32':  # nocover
+    # NOTE: LOCALAPPDATA is not available on Windows XP
+    get_data_dir = partial(_get_dir, 'LOCALAPPDATA',
+                           os.path.expanduser('~/AppData/Local'))
+    get_config_dir = partial(_get_dir, 'LOCALAPPDATA',
+                             os.path.expanduser('~/AppData/Local'))
+else:
+    get_data_dir = partial(_get_dir, 'XDG_DATA_HOME',
+                           os.path.expanduser('~/.local/share'))
+    get_config_dir = partial(_get_dir, 'XDG_CONFIG_HOME',
+                             os.path.expanduser('~/.config'))

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+
+class TempAppDirTestCase(unittest.TestCase):
+    """Set up temporary app data and config directories before every test
+    method, and delete them afterwards.
+    """
+    def setUp(self):
+        # Create a temp dir that will contain data and config directories
+        self.temp_dir = tempfile.mkdtemp()
+
+        if sys.platform == 'win32':
+            self.homes = {
+                # subdir_name: envvar_name
+                'data': 'LOCALAPPDATA',
+                'config': 'LOCALAPPDATA'
+            }
+        else:
+            self.homes = {
+                # subdir_name: envvar_name
+                'data': 'XDG_DATA_HOME',
+                'config': 'XDG_CONFIG_HOME'
+            }
+
+        # Used to restore
+        self.orig_envvars = {}
+
+        for subdir_name, envvar_name in self.homes.items():
+            if envvar_name in os.environ:
+                self.orig_envvars[envvar_name] = os.environ[envvar_name]
+            os.environ[envvar_name] = os.path.join(self.temp_dir, subdir_name)
+
+    def tearDown(self):
+        # Restore envvar values
+        for name in self.homes.values():
+            if name in self.orig_envvars:
+                os.environ[name] = self.orig_envvars[name]
+            else:
+                del os.environ[name]
+
+        shutil.rmtree(self.temp_dir)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -109,3 +109,26 @@ def test_httpie_args_post():
         'email=jane@example.com', "'name=Jane Doe'",
         'Accept:text/html', "'Authorization:ApiKey 1234'",
     ]
+
+
+def test_json_serializing():
+    c = Context('http://example.com/api')
+    c.headers.update({
+        'Authorization': 'ApiKey 1234',
+        'Accept': 'text/html'
+    })
+    c.options['--form'] = None
+    c.body_params.update({
+        'name': 'Jane Doe',
+        'email': 'jane@example.com'
+    })
+
+    json_obj = c.json_obj()
+
+    c2 = c.copy()
+    c2.headers['Accept'] = 'application/json'
+    c2.body_params['name'] = 'Jane Doe'
+    assert c2 != c
+
+    c2.load_from_json_obj(json_obj)
+    assert c2 == c

--- a/tests/test_interaction.py
+++ b/tests/test_interaction.py
@@ -1,20 +1,24 @@
+import os
 import sys
 
 import pexpect
 import pytest
 
+from .base import TempAppDirTestCase
 from .utils import get_http_prompt_path
 
 
-@pytest.mark.skipif(sys.platform == 'win32',
-                    reason="pexpect doesn't work well on Windows")
-@pytest.mark.slow
-def test_interaction():
-    bin_path = get_http_prompt_path()
-    child = pexpect.spawn(bin_path)
+class TestInteraction(TempAppDirTestCase):
 
-    # TODO: Test more interaction
+    @pytest.mark.skipif(sys.platform == 'win32',
+                        reason="pexpect doesn't work well on Windows")
+    @pytest.mark.slow
+    def test_interaction(self):
+        bin_path = get_http_prompt_path()
+        child = pexpect.spawn(bin_path, env=os.environ)
 
-    child.sendline('exit')
-    child.expect_exact('Goodbye!', timeout=20)
-    child.close()
+        # TODO: Test more interaction
+
+        child.sendline('exit')
+        child.expect_exact('Goodbye!', timeout=20)
+        child.close()

--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -1,5 +1,6 @@
 import os
 import stat
+import sys
 
 from .base import TempAppDirTestCase
 from http_prompt import xdg
@@ -12,29 +13,33 @@ class TestXDG(TempAppDirTestCase):
         expected_path = os.path.join(os.environ[self.homes['data']],
                                      'http-prompt')
         self.assertEqual(path, expected_path)
+        self.assertTrue(os.path.exists(path))
 
-        # Make sure permission for the directory is 700
-        mask = stat.S_IMODE(os.stat(path).st_mode)
-        self.assertTrue(mask & stat.S_IRWXU)
-        self.assertFalse(mask & stat.S_IRWXG)
-        self.assertFalse(mask & stat.S_IRWXO)
+        if sys.platform != 'win32':
+            # Make sure permission for the directory is 700
+            mask = stat.S_IMODE(os.stat(path).st_mode)
+            self.assertTrue(mask & stat.S_IRWXU)
+            self.assertFalse(mask & stat.S_IRWXG)
+            self.assertFalse(mask & stat.S_IRWXO)
 
     def test_get_app_config_home(self):
         path = xdg.get_config_dir()
         expected_path = os.path.join(os.environ[self.homes['config']],
                                      'http-prompt')
         self.assertEqual(path, expected_path)
+        self.assertTrue(os.path.exists(path))
 
-        # Make sure permission for the directory is 700
-        mask = stat.S_IMODE(os.stat(path).st_mode)
-        self.assertTrue(mask & stat.S_IRWXU)
-        self.assertFalse(mask & stat.S_IRWXG)
-        self.assertFalse(mask & stat.S_IRWXO)
+        if sys.platform != 'win32':
+            # Make sure permission for the directory is 700
+            mask = stat.S_IMODE(os.stat(path).st_mode)
+            self.assertTrue(mask & stat.S_IRWXU)
+            self.assertFalse(mask & stat.S_IRWXG)
+            self.assertFalse(mask & stat.S_IRWXO)
 
     def test_get_resource_data_dir(self):
         path = xdg.get_data_dir('something')
         expected_path = os.path.join(
-            os.environ['XDG_DATA_HOME'], 'http-prompt', 'something')
+            os.environ[self.homes['data']], 'http-prompt', 'something')
         self.assertEqual(path, expected_path)
         self.assertTrue(os.path.exists(path))
 
@@ -45,7 +50,7 @@ class TestXDG(TempAppDirTestCase):
     def test_get_resource_config_dir(self):
         path = xdg.get_config_dir('something')
         expected_path = os.path.join(
-            os.environ['XDG_CONFIG_HOME'], 'http-prompt', 'something')
+            os.environ[self.homes['config']], 'http-prompt', 'something')
         self.assertEqual(path, expected_path)
         self.assertTrue(os.path.exists(path))
 

--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -1,0 +1,92 @@
+import os
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+
+from http_prompt import xdg
+
+
+class TestXDG(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temp dir that will contain data and config directories
+        self.temp_dir = tempfile.mkdtemp()
+
+        if sys.platform == 'win32':
+            self.homes = {
+                # subdir_name: envvar_name
+                'data': 'LOCALAPPDATA',
+                'config': 'LOCALAPPDATA'
+            }
+        else:
+            self.homes = {
+                # subdir_name: envvar_name
+                'data': 'XDG_DATA_HOME',
+                'config': 'XDG_CONFIG_HOME'
+            }
+
+        # Used to restore
+        self.orig_envvars = {}
+
+        for subdir_name, envvar_name in self.homes.items():
+            if envvar_name in os.environ:
+                self.orig_envvars[envvar_name] = os.environ[envvar_name]
+            os.environ[envvar_name] = os.path.join(self.temp_dir, subdir_name)
+
+    def tearDown(self):
+        # Restore envvar values
+        for name in self.homes.values():
+            if name in self.orig_envvars:
+                os.environ[name] = self.orig_envvars[name]
+            else:
+                del os.environ[name]
+
+        shutil.rmtree(self.temp_dir)
+
+    def test_get_app_data_home(self):
+        path = xdg.get_data_dir()
+        expected_path = os.path.join(os.environ[self.homes['data']],
+                                     'http-prompt')
+        self.assertEqual(path, expected_path)
+
+        # Make sure permission for the directory is 700
+        mask = stat.S_IMODE(os.stat(path).st_mode)
+        self.assertTrue(mask & stat.S_IRWXU)
+        self.assertFalse(mask & stat.S_IRWXG)
+        self.assertFalse(mask & stat.S_IRWXO)
+
+    def test_get_app_config_home(self):
+        path = xdg.get_config_dir()
+        expected_path = os.path.join(os.environ[self.homes['config']],
+                                     'http-prompt')
+        self.assertEqual(path, expected_path)
+
+        # Make sure permission for the directory is 700
+        mask = stat.S_IMODE(os.stat(path).st_mode)
+        self.assertTrue(mask & stat.S_IRWXU)
+        self.assertFalse(mask & stat.S_IRWXG)
+        self.assertFalse(mask & stat.S_IRWXO)
+
+    def test_get_resource_data_dir(self):
+        path = xdg.get_data_dir('something')
+        expected_path = os.path.join(
+            os.environ['XDG_DATA_HOME'], 'http-prompt', 'something')
+        self.assertEqual(path, expected_path)
+        self.assertTrue(os.path.exists(path))
+
+        # Make sure we can write a file to the directory
+        with open(os.path.join(path, 'test'), 'wb') as f:
+            f.write(b'hello')
+
+    def test_get_resource_config_dir(self):
+        path = xdg.get_config_dir('something')
+        expected_path = os.path.join(
+            os.environ['XDG_CONFIG_HOME'], 'http-prompt', 'something')
+        self.assertEqual(path, expected_path)
+        self.assertTrue(os.path.exists(path))
+
+        # Make sure we can write a file to the directory
+        with open(os.path.join(path, 'test'), 'wb') as f:
+            f.write(b'hello')

--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -1,49 +1,11 @@
 import os
-import shutil
 import stat
-import sys
-import tempfile
-import unittest
 
+from .base import TempAppDirTestCase
 from http_prompt import xdg
 
 
-class TestXDG(unittest.TestCase):
-
-    def setUp(self):
-        # Create a temp dir that will contain data and config directories
-        self.temp_dir = tempfile.mkdtemp()
-
-        if sys.platform == 'win32':
-            self.homes = {
-                # subdir_name: envvar_name
-                'data': 'LOCALAPPDATA',
-                'config': 'LOCALAPPDATA'
-            }
-        else:
-            self.homes = {
-                # subdir_name: envvar_name
-                'data': 'XDG_DATA_HOME',
-                'config': 'XDG_CONFIG_HOME'
-            }
-
-        # Used to restore
-        self.orig_envvars = {}
-
-        for subdir_name, envvar_name in self.homes.items():
-            if envvar_name in os.environ:
-                self.orig_envvars[envvar_name] = os.environ[envvar_name]
-            os.environ[envvar_name] = os.path.join(self.temp_dir, subdir_name)
-
-    def tearDown(self):
-        # Restore envvar values
-        for name in self.homes.values():
-            if name in self.orig_envvars:
-                os.environ[name] = self.orig_envvars[name]
-            else:
-                del os.environ[name]
-
-        shutil.rmtree(self.temp_dir)
+class TestXDG(TempAppDirTestCase):
 
     def test_get_app_data_home(self):
         path = xdg.get_data_dir()


### PR DESCRIPTION
This PR implements a new feature called **persistent context**. Every time a user types a command and hits enter, http-prompt saves the current context (headers, options, and parameters) to the disk. When the user restarts http-prompt and revisit the same host, the context is loaded back from the disk, so the user can keep working on the same context again without re-entering all those parameters.

Related issues: #10 and #26 