### PR TITLE
User config

### DIFF
--- a/http_prompt/config.py
+++ b/http_prompt/config.py
@@ -1,0 +1,70 @@
+"""Functions that deal with the user configuration."""
+
+import os
+import shutil
+
+import six
+
+from . import defaultconfig
+from . import xdg
+
+
+def get_user_config_path():
+    """Get the path to the user config file."""
+    return os.path.join(xdg.get_config_dir(), 'config.py')
+
+
+def initialize():
+    """Initialize a default config file if it doesn't exist yet.
+
+    Returns:
+        tuple: A tuple of (copied, dst_path). `copied` is a bool indicating if
+            this function created the default config file. `dst_path` is the
+            path of the user config file.
+    """
+    dst_path = get_user_config_path()
+    copied = False
+    if not os.path.exists(dst_path):
+        src_path = os.path.join(os.path.dirname(__file__), 'defaultconfig.py')
+        shutil.copyfile(src_path, dst_path)
+        copied = True
+    return copied, dst_path
+
+
+def _module_to_dict(module):
+    attrs = {}
+    attr_names = filter(lambda n: not n.startswith('_'), dir(module))
+    for name in attr_names:
+        value = getattr(module, name)
+        attrs[name] = value
+    return attrs
+
+
+def load_default():
+    """Return default config as a dict."""
+    return _module_to_dict(defaultconfig)
+
+
+def load_user():
+    """Read user config file and return it as a dict."""
+    config_path = get_user_config_path()
+    config = {}
+
+    # TODO: This may be overkill and too slow just for reading a config file
+    with open(config_path) as f:
+        code = compile(f.read(), config_path, 'exec')
+    exec(code, config)
+
+    keys = list(six.iterkeys(config))
+    for k in keys:
+        if k.startswith('_'):
+            del config[k]
+
+    return config
+
+
+def load():
+    """Read default and user config files and return them as a dict."""
+    config = load_default()
+    config.update(load_user())
+    return config

--- a/http_prompt/contextio.py
+++ b/http_prompt/contextio.py
@@ -1,0 +1,39 @@
+"""Serialization and deserialization of a Context object."""
+
+import json
+import os
+
+from six.moves.urllib.parse import urlparse
+
+from . import xdg
+
+
+# Don't save these HTTPie options to avoid collision with user config file
+EXCLUDED_OPTIONS = ['--style']
+
+
+def load_context(context):
+    """Load a Context object in place from user data directory."""
+    dir_path = xdg.get_data_dir('context')
+    host = urlparse(context.url).hostname
+    file_path = os.path.join(dir_path, host)
+    if os.path.exists(file_path):
+        with open(file_path) as f:
+            json_obj = json.load(f)
+        context.load_from_json_obj(json_obj)
+        context.should_exit = False
+
+
+def save_context(context):
+    """Save a Context object to user data directory."""
+    dir_path = xdg.get_data_dir('context')
+    host = urlparse(context.url).hostname
+    file_path = os.path.join(dir_path, host)
+    json_obj = context.json_obj()
+
+    options = json_obj['options']
+    for name in EXCLUDED_OPTIONS:
+        options.pop(name, None)
+
+    with open(file_path, 'w') as f:
+        json.dump(json_obj, f, indent=4)

--- a/http_prompt/default_config.py
+++ b/http_prompt/default_config.py
@@ -1,0 +1,11 @@
+# Highlighting styles for prompt commands and response output.
+# Available values:
+# algol, algol_nu, autumn, borland, bw, colorful, default, emacs, friendly,
+# fruity, igor, lovelace, manni, monokai, murphy, native, paraiso-dark,
+# paraiso-light, pastie, perldoc, rrt, tango, trac, vim, vs, xcode
+command_style = 'monokai'
+output_style = 'monokai'
+
+# The tool used to paginate output. Available values: 'less' and 'more'.
+# Note that 'more' does not support ANSI colors.
+pager = 'less'

--- a/http_prompt/defaultconfig.py
+++ b/http_prompt/defaultconfig.py
@@ -1,10 +1,12 @@
-# Highlighting styles for prompt commands and response output.
-# Available values:
+# Highlighting style for prompt commands. Available values:
 # algol, algol_nu, autumn, borland, bw, colorful, default, emacs, friendly,
 # fruity, igor, lovelace, manni, monokai, murphy, native, paraiso-dark,
 # paraiso-light, pastie, perldoc, rrt, tango, trac, vim, vs, xcode
 command_style = 'monokai'
-output_style = 'monokai'
+
+# Highlighting style for HTTPie's output. Available values are the same as
+# command_style. Set this to None to use HTTPie's default setting.
+output_style = None
 
 # The tool used to paginate output. Available values: 'less' and 'more'.
 # Note that 'more' does not support ANSI colors.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,10 @@
+import os
+
 from click.testing import CliRunner
 from mock import patch
 
 from .base import TempAppDirTestCase
+from http_prompt import xdg
 from http_prompt.cli import cli, execute
 
 
@@ -85,3 +88,14 @@ class TestCli(TempAppDirTestCase):
         self.assertEqual(context.body_params, {'name': 'bob', 'sex': 'M'})
         self.assertEqual(context.headers, {})
         self.assertEqual(context.querystring_params, {'id': '10'})
+
+    def test_config_file(self):
+        # Config file is not there at the beginning
+        config_path = os.path.join(xdg.get_config_dir(), 'config.py')
+        self.assertFalse(os.path.exists(config_path))
+
+        # After user runs it for the first time, a default config file should
+        # be created
+        result, context = run_and_exit(['//example.com'])
+        self.assertEqual(result.exit_code, 0)
+        self.assertTrue(os.path.exists(config_path))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,70 @@
+import hashlib
+import os
+
+from .base import TempAppDirTestCase
+from http_prompt import config
+
+
+def _hash_file(path):
+    with open(path, 'rb') as f:
+        data = f.read()
+    return hashlib.sha1(data).hexdigest()
+
+
+class TestConfig(TempAppDirTestCase):
+
+    def test_initialize(self):
+        # Config file doesn't exist at first
+        expected_path = config.get_user_config_path()
+        self.assertFalse(os.path.exists(expected_path))
+
+        # Config file should exist after initialization
+        copied, actual_path = config.initialize()
+        self.assertTrue(copied)
+        self.assertEqual(actual_path, expected_path)
+        self.assertTrue(os.path.exists(expected_path))
+
+        # Change config file and hash the content to see if it's changed
+        with open(expected_path, 'a') as f:
+            f.write('dont_care\n')
+        orig_hash = _hash_file(expected_path)
+
+        # Make sure it's fine to call config.initialize() twice
+        copied, actual_path = config.initialize()
+        self.assertFalse(copied)
+        self.assertEqual(actual_path, expected_path)
+        self.assertTrue(os.path.exists(expected_path))
+
+        # Make sure config file is unchanged
+        new_hash = _hash_file(expected_path)
+        self.assertEqual(new_hash, orig_hash)
+
+    def test_load_default(self):
+        cfg = config.load_default()
+        self.assertEqual(cfg['command_style'], 'monokai')
+        self.assertFalse(cfg['output_style'])
+        self.assertEqual(cfg['pager'], 'less')
+
+    def test_load_user(self):
+        copied, path = config.initialize()
+        self.assertTrue(copied)
+
+        with open(path, 'w') as f:
+            f.write("\ngreeting = 'hello!'\n")
+
+        cfg = config.load_user()
+        self.assertEqual(cfg, {'greeting': 'hello!'})
+
+    def test_load(self):
+        copied, path = config.initialize()
+        self.assertTrue(copied)
+
+        with open(path, 'w') as f:
+            f.write("pager = 'more'\n"
+                    "greeting = 'hello!'\n")
+
+        cfg = config.load()
+        self.assertEqual(cfg['command_style'], 'monokai')
+        self.assertFalse(cfg['output_style'])
+        self.assertEqual(cfg['pager'], 'more')
+        self.assertEqual(cfg['greeting'], 'hello!')

--- a/tests/test_contextio.py
+++ b/tests/test_contextio.py
@@ -1,0 +1,35 @@
+from .base import TempAppDirTestCase
+
+from http_prompt.context import Context
+from http_prompt.contextio import load_context, save_context
+
+
+class TestContextIO(TempAppDirTestCase):
+
+    def test_save_and_load(self):
+        c = Context('http://example.com')
+        c.headers['Authorization'] = 'apikey'
+        c.querystring_params.update({
+            'type': 'any',
+            'offset': '100'
+        })
+        c.options.update({
+            '--verify': 'no',
+            '--style': 'default',
+            '--follow': None
+        })
+
+        save_context(c)
+
+        c2 = Context('http://example.com')
+        load_context(c2)
+
+        self.assertEqual(c2.headers, c.headers)
+        self.assertEqual(c2.querystring_params, c.querystring_params)
+        self.assertEqual(c2.body_params, c.body_params)
+
+        # Make sure save_context() didn't save '--style'
+        self.assertEqual(c2.options, {
+            '--verify': 'no',
+            '--follow': None
+        })


### PR DESCRIPTION
This PR allows a user to configure user preferences using a config file. The config file is a Python file named `config.py` located in the config directory. Besides the config directory, there is a data directory used to store session history. The following table list their locations:

| | Unix-like (Linux and OS X) | Windows |
|---|---|---|
|Config directory|`$XDG_CONFIG_HOME/http-prompt`|`%LOCALAPPDATA%/http-prompt`|
|Data directory|`$XDG_DATA_HOME/http-prompt`|`%LOCALAPPDATA%/http-prompt`|

If environment variables are undefined, the locations default to the following values:

| | Unix-like (Linux and OS X) | Windows |
|---|---|---|
|Config directory|`~/.config/http-prompt`|`~/AppData/Local/http-prompt`|
|Data directory|`~/.local/share/http-prompt`|`~/AppData/Local/http-prompt`|