### PR TITLE
Refactor context loading using execution event listener

### DIFF
--- a/http_prompt/context.py
+++ b/http_prompt/context.py
@@ -87,4 +87,4 @@ class Context(object):
         return obj
 
     def load_from_json_obj(self, json_obj):
-        self.__dict__ = deepcopy(json_obj)
+        self.__dict__.update(deepcopy(json_obj))

--- a/http_prompt/contextio.py
+++ b/http_prompt/contextio.py
@@ -8,11 +8,14 @@ from six.moves.urllib.parse import urlparse
 from . import xdg
 
 
+# Don't save these attributes of a Context object
+EXCLUDED_ATTRS = ['url', 'should_exit']
+
 # Don't save these HTTPie options to avoid collision with user config file
 EXCLUDED_OPTIONS = ['--style']
 
 
-def _url_to_filename(url):
+def url_to_context_filename(url):
     r = urlparse(url)
     host = r.hostname
     port = r.port
@@ -24,7 +27,7 @@ def _url_to_filename(url):
 def load_context(context):
     """Load a Context object in place from user data directory."""
     dir_path = xdg.get_data_dir('context')
-    filename = _url_to_filename(context.url)
+    filename = url_to_context_filename(context.url)
     file_path = os.path.join(dir_path, filename)
     if os.path.exists(file_path):
         with open(file_path) as f:
@@ -36,9 +39,12 @@ def load_context(context):
 def save_context(context):
     """Save a Context object to user data directory."""
     dir_path = xdg.get_data_dir('context')
-    filename = _url_to_filename(context.url)
+    filename = url_to_context_filename(context.url)
     file_path = os.path.join(dir_path, filename)
     json_obj = context.json_obj()
+
+    for name in EXCLUDED_ATTRS:
+        json_obj.pop(name, None)
 
     options = json_obj['options']
     for name in EXCLUDED_OPTIONS:


### PR DESCRIPTION
execution.py deals with all execution logic. But cli.py, an outsider module, may be interested in some events. For instance, when a user changes their base URL using `cd`, we should reload the context from the filesystem. This commit implements "execution event listener" to do such a thing.