### PR TITLE
Fix bug: Let parser match longer argument first

### DIFF
--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -60,8 +60,8 @@ grammar = Grammar(r"""
                    "--version" / "--traceback" / "--debug"
     value_option_mut = _ value_optname ~r"(\s+|=)" string _
     value_optname = "--pretty" / "--style" / "-s" / "--print" / "-p" /
-                    "--output" / "-o" / "--session" / "--session-read-only" /
-                    "--auth" / "-a" / "--auth-type" / "--proxy" / "--verify" /
+                    "--output" / "-o" / "--session-read-only" / "--session" /
+                    "--auth-type" / "--auth" / "-a" / "--proxy" / "--verify" /
                     "--cert" / "--cert-key" / "--timeout"
 
     cd = _ "cd" _ string _

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -366,6 +366,15 @@ class TestMutation(ExecutionTestCase):
             '--auth': 'user:pass'
         })
 
+    def test_long_option_names_with_its_prefix(self):
+        execute('--auth-type basic --auth user:pass --session user --session-read-only user', self.context)
+        self.assertEqual(self.context.options, {
+            '--auth-type': 'basic',
+            '--auth': 'user:pass',
+            '--session-read-only': 'user',
+            '--session': 'user'
+        })
+
     def test_long_short_option_names_mixed(self):
         execute('--style=default -j --stream', self.context)
         self.assertEqual(self.context.options, {


### PR DESCRIPTION
a quick patch that fix following bug:
```
http://localhost> --session-read-only test
Syntax error near "--session-"
http://localhost> --auth-type test
Syntax error near "--auth-typ"
```

after applying the patch:
```
http://localhost> --session-read-only test
http://localhost> --auth-type test
http://localhost> httpie
http --auth-type test --session-read-only test http://localhost --session-read-only=test
```