### PR TITLE
shell commands - lexer rules, pipe to shell cmd redirection, tests

### DIFF
--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -27,8 +27,8 @@ grammar = Grammar(r"""
 
     concat_mut = option_mut / full_quoted_mut / value_quoted_mut / unquoted_mut
     nonconcat_mut = cd / rm
-    preview = _ tool _ (method _)? (urlpath _)? concat_mut* &shell_cmd_redir?
-    action = _ method _ (urlpath _)? concat_mut* &shell_cmd_redir?
+    preview = _ tool _ (method _)? (urlpath _)? concat_mut*
+    action = _ method _ (urlpath _)? concat_mut*
     urlpath = (~r"https?://" unquoted_string) / (!concat_mut !shell_cmd_redir string)
     help = _ "help" _
     exit = _ "exit" _
@@ -315,9 +315,11 @@ class ExecutionVisitor(NodeVisitor):
                 self.last_response = arg
 
     def visit_immutation(self, node, children):
-        parsed = re.search(r"\s*(\|)\s*(.*)", node.text)
+        # check if command is redirected to a shell eg.: "> httpie | tee /tmp/log"
+        parsed = re.search(r"\s*\|\s*(.*)", node.text)
         if self.output_data is not None and parsed is None:
             click.echo_via_pager(self.output_data)
+
         return node
 
     def visit_action(self, node, children):

--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -315,9 +315,7 @@ class ExecutionVisitor(NodeVisitor):
                 self.last_response = arg
 
     def visit_immutation(self, node, children):
-        # check if command is redirected to a shell eg.: "> httpie | tee /tmp/log"
-        parsed = re.search(r"\s*\|\s*(.*)", node.text)
-        if self.output_data is not None and parsed is None:
+        if self.output_data is not None:
             click.echo_via_pager(self.output_data)
 
         return node
@@ -385,7 +383,8 @@ class ExecutionVisitor(NodeVisitor):
             exc = CalledProcessError(p.returncode, node.text)
             exc.output = text_type(err or out, 'utf-8').rstrip()
             raise exc
-        return text_type(out, 'utf-8').rstrip()
+        self.output_data = text_type(out, 'utf-8').rstrip()
+        return self.output_data
 
     def generic_visit(self, node, children):
         if not node.expr_name and node.children:

--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -23,7 +23,7 @@ grammar = Grammar(r"""
     command = mutation / immutation
 
     mutation = concat_mut+ / nonconcat_mut
-    immutation = ((preview / action / help / exit) shell_cmd_redir?) / _
+    immutation = ((preview / action / help ) shell_cmd_redir?) / exit / _
 
     concat_mut = option_mut / full_quoted_mut / value_quoted_mut / unquoted_mut
     nonconcat_mut = cd / rm

--- a/http_prompt/execution.py
+++ b/http_prompt/execution.py
@@ -27,9 +27,9 @@ grammar = Grammar(r"""
 
     concat_mut = option_mut / full_quoted_mut / value_quoted_mut / unquoted_mut
     nonconcat_mut = cd / rm
-    preview = _ tool _ (method _)? (urlpath _)? concat_mut*
-    action = _ method _ (urlpath _)? concat_mut*
-    urlpath = (~r"https?://" unquoted_string) / (!concat_mut string)
+    preview = _ tool _ (method _)? (urlpath _)? concat_mut* shell_cmd_redir?
+    action = _ method _ (urlpath _)? concat_mut* shell_cmd_redir?
+    urlpath = (~r"https?://" unquoted_string) / (!concat_mut !shell_cmd_redir string)
     help = _ "help" _
     exit = _ "exit" _
 
@@ -90,6 +90,7 @@ grammar = Grammar(r"""
 
     code_block = "`" shell_code "`"
     shell_code = ~r"[^`]*"
+    shell_cmd_redir = _ "|" _ (shell_code / code_block)
 """)
 
 

--- a/http_prompt/lexer.py
+++ b/http_prompt/lexer.py
@@ -1,4 +1,4 @@
-from pygments.lexer import RegexLexer, bygroups, words, using
+from pygments.lexer import RegexLexer, bygroups, words, using, include, combined
 from pygments.lexers import BashLexer
 
 from pygments.token import Text, String, Keyword, Name, Operator
@@ -56,30 +56,34 @@ class HttpPromptLexer(RegexLexer):
         ],
         'rm_name': string_rules('end'),
 
+        'shell_command': [
+            (r'(`)([^`]*)(`)', bygroups(Text, using(BashLexer), Text)),
+        ],
         'concat_mut': [
             (r'$', Text, 'end'),
             (r'\s+', Text),
 
             # Flag options, such as (--form) and (--json)
-            (words(FLAG_OPTIONS, suffix=r'\b'), Name),
+            (words(FLAG_OPTIONS, suffix=r'\b'), Name, 'concat_mut'),
 
             # Options with values, such as (--style=default) and (--pretty all)
-            (words(VALUE_OPTIONS, suffix=r'\b'), Name, 'option_op'),
+            (words(VALUE_OPTIONS, suffix=r'\b'), Name,
+             combined('shell_command', 'option_op')),
 
-            (r'(`)([^`]*)(`)', bygroups(Text, using(BashLexer), Text)),
+            include('shell_command'),
 
             # Unquoted or value-quoted request mutation,
             # such as (name="John Doe") and (name=John\ Doe)
             (r'((?:[^\s\'"\\=:]|(?:\\.))*)(:|==|=)',
-             bygroups(Name, Operator), 'unquoted_mut'),
+             bygroups(Name, Operator), combined('shell_command', 'unquoted_mut')),
 
             # Full single-quoted request mutation, such as ('name=John Doe')
             (r"(')((?:[^\r\n'\\=:]|(?:\\.))+)(:|==|=)",
-             bygroups(Text, Name, Operator), 'squoted_mut'),
+             bygroups(Text, Name, Operator), combined('shell_command', 'squoted_mut')),
 
             # Full double-quoted request mutation, such as ("name=John Doe")
             (r'(")((?:[^\r\n"\\=:]|(?:\\.))+)(:|==|=)',
-             bygroups(Text, Name, Operator), 'dquoted_mut')
+             bygroups(Text, Name, Operator), combined('shell_command', 'dquoted_mut'))
         ],
 
         'option_op': [

--- a/http_prompt/lexer.py
+++ b/http_prompt/lexer.py
@@ -60,7 +60,7 @@ class HttpPromptLexer(RegexLexer):
             (r'(`)([^`]*)(`)', bygroups(Text, using(BashLexer), Text)),
         ],
         'shell_redirection': [
-            (r'\s*(\|)([^`]*)', bygroups(Keyword, using(BashLexer))),
+            (r'\s*(\|)(.*)', bygroups(Keyword, using(BashLexer))),
         ],
         'concat_mut': [
             (r'$', Text, 'end'),
@@ -111,7 +111,8 @@ class HttpPromptLexer(RegexLexer):
             (r'', Text, 'urlpath')
         ],
         'urlpath': [
-            (r'https?://([^\s"\'\\]|(\\.))+', String, combined('concat_mut', 'shell_redirection')),
+            (r'https?://([^\s"\'\\]|(\\.))+', String,
+             combined('concat_mut', 'shell_redirection')),
 
             (r'(")(https?://(?:[^\r\n"\\]|(?:\\.))+)(")',
              bygroups(Text, String, Text), combined('concat_mut', 'shell_redirection')),
@@ -133,7 +134,8 @@ class HttpPromptLexer(RegexLexer):
 
             (r"(')((?:[^\r\n'\\=:]|(?:\\.))+)", bygroups(Text, String)),
 
-            (r'([^\-]([^\s"\'\\=:]|(\\.))+)(\s+|$)', String, combined('concat_mut', 'shell_redirection')),
+            (r'([^\-]([^\s"\'\\=:]|(\\.))+)(\s+|$)', String,
+             combined('concat_mut', 'shell_redirection')),
             (r'', Text, combined('concat_mut', 'shell_redirection'))
         ],
 

--- a/http_prompt/lexer.py
+++ b/http_prompt/lexer.py
@@ -59,6 +59,9 @@ class HttpPromptLexer(RegexLexer):
         'shell_command': [
             (r'(`)([^`]*)(`)', bygroups(Text, using(BashLexer), Text)),
         ],
+        'shell_redirection': [
+            (r'\s*(\|)([^`]*)', bygroups(Keyword, using(BashLexer))),
+        ],
         'concat_mut': [
             (r'$', Text, 'end'),
             (r'\s+', Text),
@@ -103,34 +106,35 @@ class HttpPromptLexer(RegexLexer):
 
         'preview_action': [
             (r'(?i)(get|head|post|put|patch|delete)(\s*)',
-             bygroups(Keyword, Text), 'urlpath'),
+             bygroups(Keyword, Text), combined('urlpath', 'shell_redirection')),
+            include('shell_redirection'),
             (r'', Text, 'urlpath')
         ],
         'urlpath': [
-            (r'https?://([^\s"\'\\]|(\\.))+', String, 'concat_mut'),
+            (r'https?://([^\s"\'\\]|(\\.))+', String, combined('concat_mut', 'shell_redirection')),
 
             (r'(")(https?://(?:[^\r\n"\\]|(?:\\.))+)(")',
-             bygroups(Text, String, Text), 'concat_mut'),
+             bygroups(Text, String, Text), combined('concat_mut', 'shell_redirection')),
 
             (r'(")(https?://(?:[^\r\n"\\]|(?:\\.))+)', bygroups(Text, String)),
 
             (r"(')(https?://(?:[^\r\n'\\]|(?:\\.))+)(')",
-             bygroups(Text, String, Text), 'concat_mut'),
+             bygroups(Text, String, Text), combined('concat_mut', 'shell_redirection')),
 
             (r"(')(https?://(?:[^\r\n'\\]|(?:\\.))+)", bygroups(Text, String)),
 
             (r'(")((?:[^\r\n"\\=:]|(?:\\.))+)(")',
-             bygroups(Text, String, Text), 'concat_mut'),
+             bygroups(Text, String, Text), combined('concat_mut', 'shell_redirection')),
 
             (r'(")((?:[^\r\n"\\=:]|(?:\\.))+)', bygroups(Text, String)),
 
             (r"(')((?:[^\r\n'\\=:]|(?:\\.))+)(')",
-             bygroups(Text, String, Text), 'concat_mut'),
+             bygroups(Text, String, Text), combined('concat_mut', 'shell_redirection')),
 
             (r"(')((?:[^\r\n'\\=:]|(?:\\.))+)", bygroups(Text, String)),
 
-            (r'([^\-]([^\s"\'\\=:]|(\\.))+)(\s+|$)', String, 'concat_mut'),
-            (r'', Text, 'concat_mut')
+            (r'([^\-]([^\s"\'\\=:]|(\\.))+)(\s+|$)', String, combined('concat_mut', 'shell_redirection')),
+            (r'', Text, combined('concat_mut', 'shell_redirection'))
         ],
 
         'end': [

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -512,23 +512,23 @@ class TestCommandPreview(ExecutionTestCase):
 
     def test_httpie_without_args(self):
         execute('httpie', self.context)
-        self.click.echo.assert_called_with('http http://localhost')
+        self.click.echo_via_pager.assert_called_with('http http://localhost')
 
     def test_httpie_with_post(self):
         execute('httpie post name=alice', self.context)
-        self.click.echo.assert_called_with(
+        self.click.echo_via_pager.assert_called_with(
             'http POST http://localhost name=alice')
         self.assertFalse(self.context.body_params)
 
     def test_httpie_with_absolute_path(self):
         execute('httpie post /api name=alice', self.context)
-        self.click.echo.assert_called_with(
+        self.click.echo_via_pager.assert_called_with(
             'http POST http://localhost/api name=alice')
         self.assertFalse(self.context.body_params)
 
     def test_httpie_with_full_url(self):
         execute('httpie post http://httpbin.org/post name=alice', self.context)
-        self.click.echo.assert_called_with(
+        self.click.echo_via_pager.assert_called_with(
             'http POST http://httpbin.org/post name=alice')
         self.assertEqual(self.context.url, 'http://localhost')
         self.assertFalse(self.context.body_params)
@@ -536,7 +536,7 @@ class TestCommandPreview(ExecutionTestCase):
     def test_httpie_with_full_https_url(self):
         execute('httpie post https://httpbin.org/post name=alice',
                 self.context)
-        self.click.echo.assert_called_with(
+        self.click.echo_via_pager.assert_called_with(
             'http POST https://httpbin.org/post name=alice')
         self.assertEqual(self.context.url, 'http://localhost')
         self.assertFalse(self.context.body_params)
@@ -545,7 +545,7 @@ class TestCommandPreview(ExecutionTestCase):
         execute(r'httpie post http://httpbin.org/post name="john doe" '
                 r"apikey==abc\ 123 'Authorization:ApiKey 1234'",
                 self.context)
-        self.click.echo.assert_called_with(
+        self.click.echo_via_pager.assert_called_with(
             "http POST http://httpbin.org/post 'apikey==abc 123' "
             "'name=john doe' 'Authorization:ApiKey 1234'")
         self.assertEqual(self.context.url, 'http://localhost')
@@ -555,7 +555,7 @@ class TestCommandPreview(ExecutionTestCase):
 
     def test_httpie_with_multi_querystring(self):
         execute('httpie get foo==1 foo==2 foo==3', self.context)
-        self.click.echo.assert_called_with(
+        self.click.echo_via_pager.assert_called_with(
             'http GET http://localhost foo==1 foo==2 foo==3')
         self.assertEqual(self.context.url, 'http://localhost')
         self.assertFalse(self.context.querystring_params)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -12,6 +12,8 @@ from mock import patch
 from http_prompt.context import Context
 from http_prompt.execution import execute
 
+from .base import TempAppDirTestCase
+
 
 class ExecutionTestCase(unittest.TestCase):
 
@@ -561,7 +563,21 @@ class TestCommandPreview(ExecutionTestCase):
         self.assertFalse(self.context.querystring_params)
 
 
-class TestShellCode(ExecutionTestCase):
+class TestShellCode(TempAppDirTestCase, ExecutionTestCase):
+
+    def setUp(self):
+        ExecutionTestCase.setUp(self)
+        TempAppDirTestCase.setUp(self)
+
+    def tearDown(self):
+        ExecutionTestCase.tearDown(self)
+        TempAppDirTestCase.tearDown(self)
+
+    # def test_pipe_to_shell_cmd_redirection(self):
+        # execute("get some==data | tee /tmp/file", self.context)
+        # self.assertEqual(self.context.options, {
+            # '--auth': 'user:pass'
+        # })
 
     def test_unquoted_option(self):
         execute("--auth `echo user:pass`", self.context)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -233,3 +233,19 @@ class TestShellCode(LexerTestCase):
             (Text, 'john'),
             (Text, '`'),
         ])
+
+    def test_pipe_to_shell_cmd_redirection(self):
+        self.assertEqual(self.get_tokens('httpie post | tee "/tmp/test"'), [
+            (Keyword, 'httpie'),
+            (Keyword, 'post'),
+            (Keyword, '|'),
+            (Text, 'tee'),
+            (String.Double, '"/tmp/test"'),
+        ])
+
+        self.assertEqual(self.get_tokens('post | tee "/tmp/test"'), [
+            (Keyword, 'post'),
+            (Keyword, '|'),
+            (Text, 'tee'),
+            (String.Double, '"/tmp/test"'),
+        ])

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -185,3 +185,51 @@ class TestShellCode(LexerTestCase):
             (Operator, '=='),
             (String, 'john')
         ])
+        self.assertEqual(self.get_tokens('name==`echo john`'), [
+            (Name, 'name'),
+            (Operator, '=='),
+            (Text, '`'),
+            (Name.Builtin, 'echo'),
+            (Text, 'john'),
+            (Text, '`')
+        ])
+
+    def test_unquoted_bodystring(self):
+        self.assertEqual(self.get_tokens('`echo name`=john'), [
+            (Text, '`'),
+            (Name.Builtin, 'echo'),
+            (Text, 'name'),
+            (Text, '`'),
+            (Operator, '='),
+            (String, 'john')
+        ])
+        self.assertEqual(self.get_tokens('name=`echo john`'), [
+            (Name, 'name'),
+            (Operator, '='),
+            (Text, '`'),
+            (Name.Builtin, 'echo'),
+            (Text, 'john'),
+            (Text, '`')
+        ])
+
+    def test_header_option_value(self):
+        self.assertEqual(self.get_tokens('Accept:`echo "application/json"`'), [
+            (Name, 'Accept'),
+            (Operator, ':'),
+            (Text, '`'),
+            (Name.Builtin, 'echo'),
+            (String.Double, '"application/json"'),
+            (Text, '`'),
+        ])
+
+    def test_httpie_body_param(self):
+        self.assertEqual(self.get_tokens('httpie post name=`echo john`'), [
+            (Keyword, 'httpie'),
+            (Keyword, 'post'),
+            (Name, 'name'),
+            (Operator, '='),
+            (Text, '`'),
+            (Name.Builtin, 'echo'),
+            (Text, 'john'),
+            (Text, '`'),
+        ])


### PR DESCRIPTION
As title says... lexer rules for shell commands has been fully implemented... I've added some more tests for this as well...

I've a question, though. 
Now, it's possible to define a shell command in full single/double-quoted request mutation. For example, you can do this:

```bash
httpie post "`echo name`=value"
```

Is that the expected behavior, @eliangcs ?
If so, I'll add tests for this...
ps: I'm asking because I couldn't think of a reason why the full single/double-quoted request mutation feature  was implemented in first place...