### PR TITLE
fixbug/preview command lexer definitions (related to http method opti…

### DIFF
--- a/http_prompt/lexer.py
+++ b/http_prompt/lexer.py
@@ -12,7 +12,7 @@ __all__ = ['HttpPromptLexer']
 
 FLAG_OPTIONS = [name for name, _ in opt.FLAG_OPTIONS]
 VALUE_OPTIONS = [name for name, _ in opt.VALUE_OPTIONS]
-
+HTTP_METHODS = opt.HTTP_METHODS
 
 def string_rules(state):
     return [
@@ -43,7 +43,7 @@ class HttpPromptLexer(RegexLexer):
             (r'(rm)(\s*)', bygroups(Keyword, Text), 'rm_option'),
             (r'(httpie|curl)(\s*)', bygroups(Keyword, Text), 'action'),
 
-            (r'(?i)(get|head|post|put|patch|delete|options)(\s*)',
+            (words(HTTP_METHODS, prefix='(?i)', suffix='(\s*)'),
              bygroups(Keyword, Text), combined('redir_out', 'urlpath')),
 
             (r'(exit)(\s*)', bygroups(Keyword, Text), 'end'),
@@ -119,7 +119,7 @@ class HttpPromptLexer(RegexLexer):
         ],
 
         'action': [
-            (r'(?i)(get|head|post|put|patch|delete)(\s*)',
+            (words(HTTP_METHODS, prefix='(?i)', suffix='(\s*)'),
              bygroups(Keyword, Text),
              combined('redir_out', 'pipe', 'urlpath')),
             (r'', Text, combined('redir_out', 'pipe', 'urlpath'))

--- a/http_prompt/lexer.py
+++ b/http_prompt/lexer.py
@@ -12,7 +12,8 @@ __all__ = ['HttpPromptLexer']
 
 FLAG_OPTIONS = [name for name, _ in opt.FLAG_OPTIONS]
 VALUE_OPTIONS = [name for name, _ in opt.VALUE_OPTIONS]
-HTTP_METHODS = opt.HTTP_METHODS
+HTTP_METHODS = ('get', 'head', 'post', 'put', 'patch', 'delete', 'options')
+
 
 def string_rules(state):
     return [

--- a/http_prompt/options.py
+++ b/http_prompt/options.py
@@ -66,3 +66,5 @@ OPTION_VALUE_CHOICES = {
     '-p': PRETTY_CHOICES,
     '-s': STYLE_CHOICES,
 }
+
+HTTP_METHODS = ('get', 'head', 'post', 'put', 'patch', 'delete', 'options')

--- a/http_prompt/options.py
+++ b/http_prompt/options.py
@@ -66,5 +66,3 @@ OPTION_VALUE_CHOICES = {
     '-p': PRETTY_CHOICES,
     '-s': STYLE_CHOICES,
 }
-
-HTTP_METHODS = ('get', 'head', 'post', 'put', 'patch', 'delete', 'options')


### PR DESCRIPTION
Fixes small issue in #88  with lexer definitions:

```bash
http://127.0.0.1:3000>  httpie options test --body
```

The `test` url endpoint is highlighted as `syntax error`.

The issue has been caused by duplicated list of `http` methods.