### PR TITLE
bugfix for #101 PR raw json data export

### DIFF
--- a/http_prompt/context/transform.py
+++ b/http_prompt/context/transform.py
@@ -56,7 +56,7 @@ def _extract_httpie_request_items(context, quote=False):
             if sep == ':=':
                 json_str = json.dumps(value,
                                       sort_keys=True).replace("'", "\\'")
-                if isinstance(value, six.string_types):
+                if isinstance(value, six.string_types) and quote:
                     json_str = "'" + json_str + "'"
                 item = quote_func('%s:=%s' % (k, json_str))
                 items.append(item)

--- a/http_prompt/context/transform.py
+++ b/http_prompt/context/transform.py
@@ -56,6 +56,8 @@ def _extract_httpie_request_items(context, quote=False):
             if sep == ':=':
                 json_str = json.dumps(value,
                                       sort_keys=True).replace("'", "\\'")
+                if isinstance(value, six.string_types):
+                    json_str = "'" + json_str + "'"
                 item = quote_func('%s:=%s' % (k, json_str))
                 items.append(item)
             elif isinstance(value, (list, tuple)):

--- a/tests/context/test_transform.py
+++ b/tests/context/test_transform.py
@@ -138,3 +138,14 @@ def test_format_to_http_prompt_2():
                       "'full name=Jane Doe'\n"
                       "Accept:text/html\n"
                       "'Authorization:ApiKey 1234'\n")
+
+
+def test_format_raw_json_string_to_http_prompt():
+    c = Context('http://localhost/things')
+    c.body_json_params.update({
+        'bar': 'baz',
+    })
+
+    output = t.format_to_http_prompt(c)
+    assert output == ("cd http://localhost/things\n"
+                      "bar:='\"baz\"'\n")


### PR DESCRIPTION
When you did:

```bash

localhost> bar:=' "baz" '
```

the command that was saved into `context.hp` was equal:
> bar:="baz"

but expected (wrapped in single quotes):

> bar:='"baz"'

This causes `JSONDecodeError` when trying to load exported context.

Fixes #101 PR