### PR TITLE
when `cd` cmd is called without url, reset base url to protocol + hostname

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -609,6 +609,10 @@ class TestExecution_cd(ExecutionTestCase):
         execute('cd movie/1/', self.context)
         self.assertEqual(self.context.url, 'http://localhost/api/movie/1/')
 
+    def test_without_url(self):
+        execute('cd', self.context)
+        self.assertEqual(self.context.url, 'http://localhost')
+
 
 class TestExecution_rm(ExecutionTestCase):
 

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -610,6 +610,9 @@ class TestExecution_cd(ExecutionTestCase):
         self.assertEqual(self.context.url, 'http://localhost/api/movie/1/')
 
     def test_without_url(self):
+        execute('cd api/', self.context)
+        self.assertEqual(self.context.url, 'http://localhost/api/')
+
         execute('cd', self.context)
         self.assertEqual(self.context.url, 'http://localhost')
 


### PR DESCRIPTION
Example:

```bash
http://localhost:8000/path/to/something> cd
http://localhost:8000>
```