### PR TITLE
Use tuples inside of `str.startswith` (for multiple checks)

### DIFF
--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -34,11 +34,11 @@ click.disable_unicode_literals_warning = True
 
 
 def fix_incomplete_url(url):
-    if url.startswith('s://') or url.startswith('://'):
+    if url.startswith(('s://', '://')):
         url = 'http' + url
     elif url.startswith('//'):
         url = 'http:' + url
-    elif not url.startswith('http://') and not url.startswith('https://'):
+    elif not url.startswith(('http://', 'https://')):
         url = 'http://' + url
     return url
 


### PR DESCRIPTION
I checked the `.travis.yml` file and it says the earliest Python version being checked is `2.6`. I double-checked the docs and it looks like `str.startswith` has accepted tuples since `2.5`.

> [_Changed in version 2.5:_ Accept tuples as `prefix`.](https://docs.python.org/2.6/library/stdtypes.html?highlight=startswith#str.startswith)

```python
>>> url = 's://'
>>> url.startswith('s://') or url.startswith('://')
True
>>> url.startswith(('s://', '://'))
True

>>> url = '://'
>>> url.startswith('s://') or url.startswith('://')
True
>>> url.startswith(('s://', '://'))
True

>>> url = 'www'
>>> not url.startswith('http://') and not url.startswith('https://')
True
>>> not url.startswith(('http://', 'https://'))
True

```
