### PR TITLE
Remove extra argument from `six.u` function call

### DIFF
--- a/http_prompt/completer.py
+++ b/http_prompt/completer.py
@@ -54,7 +54,7 @@ def fuzzyfinder(text, collection):
     """https://github.com/amjith/fuzzyfinder"""
     suggestions = []
     if not isinstance(text, six.text_type):
-        text = six.u(text, 'utf-8')
+        text = six.u(text)
     pat = '.*?'.join(map(re.escape, text))
     regex = re.compile(pat, flags=re.IGNORECASE)
     for item in collection:


### PR DESCRIPTION
It looks like `six.u` only takes one argument but it was being called with two. 

```python
text = six.u(text, 'utf-8')
```

[six.u(text)](https://pythonhosted.org/six/#six.u)

```python
>>> import six
>>> text = 'test_str'
>>> six.u(text)
'test_str'
>>> six.u(text, 'utf-8')
Traceback (most recent call last):
  File "<input>", line 1, in <module>
TypeError: u() takes 1 positional argument but 2 were given

```
