### PR TITLE
Ignoring data.json file which is generated from tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 _build
 build
 dist
+data.json


### PR DESCRIPTION
There is one test called`test_get` from `TestHttpActionRedirection` suite that generates a file. 
This file should be included into .gitignore, since it's a test dump