### PR TITLE
Upgrade and pin prompt_toolkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
         brew update
         brew install "$BREW_INSTALL"
       fi
-      sudo pip install tox
+      sudo pip2 install tox
     else
       pip install -e .
       pip install -r requirements-test.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-17 Chang-Hung Liang
+Copyright (c) 2016-18 Chang-Hung Liang
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ environment:
     # click doesn't work on Python 2.6 and Windows
     # - PYTHON: "C:\\Python26"
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
+    # pytest does not support Python 3.3
+    # - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 click>=5.0
 httpie>=0.9.2
 parsimonious>=0.6.2
-prompt-toolkit>=0.60
+prompt-toolkit>=1.0.0,<2.0.0
 Pygments>=2.1.0
 six>=1.10.0


### PR DESCRIPTION
prompt_tookit 2.0.0 is going to compatible with 1.x.x, so let's pin its version until we're ready for 2.0.0.