### PR TITLE
Use host and basePath from OpenAPI spec

### DIFF
--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -89,7 +89,7 @@ def normalize_url(ctx, param, value):
               callback=normalize_url)
 @click.option('--env', help="Environment file to preload.",
               type=click.Path(exists=True))
-@click.argument('url', default='http://localhost:8000')
+@click.argument('url', default='')
 @click.argument('http_options', nargs=-1, type=click.UNPROCESSED)
 @click.version_option(message='%(version)s')
 def cli(spec, env, url, http_options):
@@ -112,12 +112,17 @@ def cli(spec, env, url, http_options):
             content = f.read().decode('utf-8')
             try:
                 spec = json.loads(content)
+                if url == '' and spec:
+                    url = spec.get('host', '') + spec.get('basePath', '')
             except json.JSONDecodeError:
                 click.secho("Warning: Specification file '%s' is not JSON" %
                             spec, err=True, fg='red')
                 spec = None
         finally:
             f.close()
+
+    if url == '':
+        url = 'http://localhost:8000'
 
     url = fix_incomplete_url(url)
     context = Context(url, spec=spec)

--- a/http_prompt/context/__init__.py
+++ b/http_prompt/context/__init__.py
@@ -15,18 +15,22 @@ class Context(object):
         # Create a tree for supporting API spec and ls command
         self.root = Node('root')
         if spec:
+            base_path = list(filter(lambda s: s,
+                                    spec.get('basePath', '').split('/')))
             paths = spec.get('paths')
             if paths:
                 for path in paths:
                     path_tokens = list(filter(lambda s: s, path.split('/')))
-                    self.root.add_path(*path_tokens)
+                    self.root.add_path(*(base_path + path_tokens))
                     endpoint = paths[path]
                     for method, info in endpoint.items():
                         params = info.get('parameters')
                         if params:
                             for param in params:
                                 if param.get('in') != 'path':
-                                    full_path = path_tokens + [param['name']]
+                                    full_path = base_path \
+                                                + path_tokens \
+                                                + [param['name']]
                                     self.root.add_path(*full_path,
                                                        node_type='file')
 


### PR DESCRIPTION
Related to #113, adds support for OpenAPI `host` and `basePath` keys.