### PR TITLE
support swagger spec in yaml format

### DIFF
--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import yaml
 import os
 import re
 import sys
@@ -113,9 +114,12 @@ def cli(spec, env, url, http_options):
             try:
                 spec = json.loads(content)
             except json.JSONDecodeError:
-                click.secho("Warning: Specification file '%s' is not JSON" %
-                            spec, err=True, fg='red')
-                spec = None
+                try:
+                    spec = yaml.load(content)
+                except yaml.YAMLError:
+                    click.secho("Warning: Specification file '%s' is neither valid JSON nor YAML" %
+                                spec, err=True, fg='red')
+                    spec = None
         finally:
             f.close()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ parsimonious>=0.6.2
 prompt-toolkit>=1.0.0,<2.0.0
 Pygments>=2.1.0
 six>=1.10.0
+PyYAML>=3.0


### PR DESCRIPTION
Swagger specs can be defined in JSON and YAML format.

This PR adds YAML support by falling back to yaml-parsing if JSON-parser throws an error. `PyYaml` is required as additional requirement.