### PR TITLE
Add custom prompt text

### DIFF
--- a/http_prompt/cli.py
+++ b/http_prompt/cli.py
@@ -27,7 +27,7 @@ from .context import Context
 from .contextio import load_context, save_context
 from .execution import execute
 from .lexer import HttpPromptLexer
-from .utils import smart_quote
+from .utils import smart_quote, get_prompt
 from .xdg import get_data_dir
 
 
@@ -160,8 +160,9 @@ def cli(spec, env, url, http_options):
 
     while True:
         try:
-            text = prompt('%s> ' % context.url, completer=completer,
-                          lexer=lexer, style=style, history=history,
+            p = get_prompt(context.url, cfg['prompt'])
+            text = prompt('%s> ' % p, completer=completer, lexer=lexer,
+                          style=style, history=history,
                           auto_suggest=AutoSuggestFromHistory(),
                           on_abort=AbortAction.RETRY, vi_mode=cfg['vi'])
         except EOFError:

--- a/http_prompt/defaultconfig.py
+++ b/http_prompt/defaultconfig.py
@@ -24,3 +24,16 @@ set_cookies = 'auto'
 # When Vi mode is enabled, you use Vi-like keybindings to edit your commands.
 # When it is disabled, you use Emacs keybindings.
 vi = False
+
+# Prompt format using the urlparse module terms.
+# Available values:
+# 'scheme': URL scheme specifier
+# 'netloc': Network location part ([] compliant on dots)
+# 'path': Hierarchical path ([] compliant on slashes)
+# 'params': Parameters for last path element
+# 'query': Query component
+# 'fragment': Fragment identifier
+# You can add a pythonic [] operator (e.g. path[-2:] returns the last two
+# elements of the variable path).
+# See https://docs.python.org/2/library/urlparse.html#module-urlparse
+prompt = '{scheme}{netloc}{path}{params}{query}{fragment}'


### PR DESCRIPTION
**New feature:**

This allows the user to customize the prompt. url is parsed and formatted with the [urlparse](https://docs.python.org/2/library/urlparse.html#module-urlparse) conventions.


**Default configuration:**

Default configuration is using the whole url (scheme, netloc, path, params, query, fragment):
`prompt = '{scheme}{netloc}{path}{params}{query}{fragment}'`

**Example:**
```
$ tail -n 1 ~/.config/http-prompt/config.py
prompt = '{netloc[1:]}{path[-2:]}'
$ http-prompt "http://www.example.org"
Version: 1.0.0
example.org/> cd foo/bar/baz
example.org/bar/baz>
Goodbye!
```

**Possible updates:**
- Add spaces or other characters around elements: `{path} ` will give `/foo >` from a `/foo` path
- Chain the index operator: `{path[-2:][1]}` will give `/f/b>` from a `moo/foo/bar` path

I might be not good enough with python to ensure myself I didn't introduced a vulnerability through `eval()` in `utils.get_prompt()`.

[Related issue](https://github.com/eliangcs/http-prompt/issues/55)