### PR TITLE
Support openapi 'servers'

### DIFF
--- a/http_prompt/context/__init__.py
+++ b/http_prompt/context/__init__.py
@@ -16,11 +16,15 @@ class Context(object):
         self.root = Node('root')
         if spec:
             if not self.url:
-                schemes = spec.get('schemes')
-                scheme = schemes[0] if schemes else 'https'
-                self.url = (scheme + '://' +
-                            spec.get('host', 'http://localhost:8000') +
-                            spec.get('basePath', ''))
+                self.url = spec.get('servers')[0].get('url')
+                if 'servers' in spec:
+                    self.url = spec.get('servers')[0].get('url')
+                else:
+                    schemes = spec.get('schemes')
+                    scheme = schemes[0] if schemes else 'https'
+                    self.url = (scheme + '://' +
+                                spec.get('host', 'http://localhost:8000') +
+                                spec.get('basePath', ''))
 
             base_path_tokens = list(filter(lambda s: s,
                                     spec.get('basePath', '').split('/')))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -181,6 +181,28 @@ class TestCli(TempAppDirTestCase):
         self.assertEqual(set([n.name for n in context.root.children]),
                          set(['users', 'orgs']))
 
+    def test_spec_from_local_yml_openapi(self):
+        spec_filepath = self.make_tempfile("""
+            openapi: "3.0.0"
+            servers:
+              - url: https://localhost:8080/
+            paths:
+              /api/users:
+                get:
+                  description:
+              /api/orgs:
+                get:
+                  description:
+        """)
+        result, context = run_and_exit(['example.com/api', "--spec",
+                                        spec_filepath])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(context.url, 'http://example.com/api')
+        self.assertEqual(set([n.name for n in context.root.children]),
+                         set(['api']))
+        self.assertEqual(set([n.name for n in context.root.ls('api')]),
+                         set(['users', 'orgs']))
+
     def test_spec_basePath(self):
         spec_filepath = self.make_tempfile(json.dumps({
             'basePath': '/api/v1',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,6 +164,23 @@ class TestCli(TempAppDirTestCase):
         self.assertEqual(set([n.name for n in context.root.children]),
                          set(['users', 'orgs']))
 
+    def test_spec_from_local_yml(self):
+        spec_filepath = self.make_tempfile("""
+            paths:
+              /users:
+                get:
+                  description:
+              /orgs:
+                get:
+                  description:
+        """)
+        result, context = run_and_exit(['example.com', "--spec",
+                                        spec_filepath])
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(context.url, 'http://example.com')
+        self.assertEqual(set([n.name for n in context.root.children]),
+                         set(['users', 'orgs']))
+
     def test_spec_basePath(self):
         spec_filepath = self.make_tempfile(json.dumps({
             'basePath': '/api/v1',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,16 +198,16 @@ class TestCli(TempAppDirTestCase):
 
     def test_spec_from_http_only(self):
         spec_url = (
-            'https://api.apis.guru/v2/specs/medium.com/1.0.0/swagger.json')
+            'https://api.apis.guru/v2/specs/medium.com/1.0/openapi.json')
         result, context = run_and_exit(['--spec', spec_url])
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(context.url, 'https://api.medium.com/v1')
+        self.assertEqual(context.url, 'https://medium2.p.rapidapi.com')
 
         lv1_names = set([node.name for node in context.root.ls()])
-        lv2_names = set([node.name for node in context.root.ls('v1')])
+        lv2_names = set([node.name for node in context.root.ls('article')])
 
-        self.assertEqual(lv1_names, set(['v1']))
-        self.assertEqual(lv2_names, set(['me', 'publications', 'users']))
+        self.assertEqual(lv1_names, set(['/', 'topfeeds', 'related_tags', 'user', 'article', 'list', 'latestposts', 'search', 'top_writer', 'publication']))
+        self.assertEqual(lv2_names, set(['{article_id}']))
 
     def test_spec_with_trailing_slash(self):
         spec_filepath = self.make_tempfile(json.dumps({


### PR DESCRIPTION
In openapi 3 the 'schemes' and 'basePath' were replaced with a single
property called 'servers', in this property we introduce the available
servers with the full path, for example:

```yaml
servers:
  - url: https://statsapi.web.nhl.com/api/v1
 ```

With this change, a flag is added in the parsing of the context
`is_open_api` that can be used to check for the new properties available
in open api 3.

fixes #197

This PR also fixes the test `test_spec_from_http_only` that relied on an old spec that is no longer available.
